### PR TITLE
feat: project memory data loading issue fixed

### DIFF
--- a/app/static/memory/js/memory.js
+++ b/app/static/memory/js/memory.js
@@ -76,17 +76,17 @@ document.addEventListener('DOMContentLoaded', () => {
         try {
             const res = await mFetch('/api/v1/timeline/teams', { headers });
             if (res.ok) {
-                const projects = await res.json();
-                if (projects.length > 0) {
-                    // Pick the project matching the selected team, or fall back to first
+                const teams = await res.json();
+                if (teams.length > 0) {
+                    // Pick the team matching localStorage, or fall back to first
                     const savedTeam = localStorage.getItem('selected_team_id');
-                    const matched = savedTeam && projects.find(p => p.team_id === parseInt(savedTeam));
-                    const chosen = matched || projects[0];
-                    currentProjectId = chosen.id;
+                    const matched = savedTeam && teams.find(t => t.id === parseInt(savedTeam));
+                    const chosen = matched || teams[0];
+                    currentTeamId = chosen.id;
                     if (projectTitle) {
-                        projectTitle.textContent = chosen.project_name || 'Project Memory';
+                        projectTitle.textContent = chosen.team_name || 'Project Memory';
                     }
-                    loadTeamData(currentTeamId);
+                    loadTeamData(chosen.id);
                 } else {
                     if (projectTitle) projectTitle.textContent = 'Project Memory';
                     timelineEmpty.style.display = 'block';
@@ -548,14 +548,14 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // Init
-    fetchProjects();
+    fetchTeams();
 
     // React to sidebar team switch
     const _teamSel = document.getElementById('teamSelect');
     if (_teamSel) {
         _teamSel.addEventListener('change', function () {
             localStorage.setItem('selected_team_id', _teamSel.value);
-            fetchProjects();
+            fetchTeams();
         });
     }
 

--- a/app/static/memory/js/memory.js
+++ b/app/static/memory/js/memory.js
@@ -91,10 +91,16 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (projectTitle) projectTitle.textContent = 'Project Memory';
                     timelineEmpty.style.display = 'block';
                 }
+            } else {
+                // Non-2xx (401, 403, 500, etc.) — don't leave the page frozen
+                console.warn('Failed to load teams, status:', res.status);
+                if (projectTitle) projectTitle.textContent = 'Project Memory';
+                if (timelineEmpty) timelineEmpty.style.display = 'block';
             }
         } catch(e) {
             console.error('Failed to fetch teams', e);
             if (projectTitle) projectTitle.textContent = 'Project Memory';
+            if (timelineEmpty) timelineEmpty.style.display = 'block';
         }
     }
 


### PR DESCRIPTION
## Bug & Fix Summary

**File:** `app/static/memory/js/memory.js`

---

### The Problem
The Project Memory page was permanently stuck on **"Loading..."** because the script crashed immediately on startup with a `ReferenceError`. The initialization line called `fetchProjects()` — a function that **doesn't exist** in the file. The real function is `fetchTeams()`. Since JavaScript throws on the first error, no data was ever fetched on any project.

Inside `fetchTeams()` itself, there were 3 additional compounding bugs:
- The result was stored in an undeclared `currentProjectId` instead of `currentTeamId`, so the team ID was always `null`
- `chosen.project_name` was read but the API returns `team_name`
- `loadTeamData(currentTeamId)` was called *before* `currentTeamId` was assigned, passing `null`

---

### The Fix
Renamed all `fetchProjects()` calls → `fetchTeams()`, corrected the variable to `currentTeamId`, the field to `team_name`, and reordered the assignment before the `loadTeamData()` call.

**Result:** Page now loads team data, timeline entries, analytics, and the project title correctly on all projects.