### PR TITLE
Copilot: Potential fix for code scanning alert no. 8: Full server-side request forgery

### DIFF
--- a/app/api/v1/rag.py
+++ b/app/api/v1/rag.py
@@ -55,6 +55,7 @@ from app.rag.processor import (
     list_folder_files,
     validate_file,
     get_doc_type,
+    validate_public_http_url,
 )
 
 router = APIRouter()
@@ -894,6 +895,10 @@ async def ingest_url(
     url = data.url.strip()
     if not url.startswith(("http://", "https://")):
         raise HTTPException(status_code=400, detail="URL must start with http:// or https://")
+    try:
+        url = validate_public_http_url(url)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
     doc_record = Document(
         team_id=data.team_id,

--- a/app/rag/processor.py
+++ b/app/rag/processor.py
@@ -589,14 +589,7 @@ def validate_public_http_url(url: str) -> str:
 
     def _is_public_ip(ip_str: str) -> bool:
         ip_obj = ipaddress.ip_address(ip_str)
-        return not (
-            ip_obj.is_private
-            or ip_obj.is_loopback
-            or ip_obj.is_link_local
-            or ip_obj.is_multicast
-            or ip_obj.is_reserved
-            or ip_obj.is_unspecified
-        )
+        return ip_obj.is_global
 
     # If host is a literal IP, validate directly.
     try:

--- a/app/rag/processor.py
+++ b/app/rag/processor.py
@@ -1,5 +1,8 @@
 import os
 import re
+import ipaddress
+import socket
+from urllib.parse import urlparse
 from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional, Tuple
 
@@ -570,6 +573,60 @@ def process_drive_url(
     return enriched, filename, doc_type, content_bytes
 
 
+def validate_public_http_url(url: str) -> str:
+    """
+    Validate URL is HTTP(S) and resolves only to public IP addresses.
+    Raises ValueError if unsafe.
+    Returns normalized URL string on success.
+    """
+    parsed = urlparse(url.strip())
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("URL must start with http:// or https://")
+    if not parsed.hostname:
+        raise ValueError("URL must include a valid hostname.")
+
+    host = parsed.hostname
+
+    def _is_public_ip(ip_str: str) -> bool:
+        ip_obj = ipaddress.ip_address(ip_str)
+        return not (
+            ip_obj.is_private
+            or ip_obj.is_loopback
+            or ip_obj.is_link_local
+            or ip_obj.is_multicast
+            or ip_obj.is_reserved
+            or ip_obj.is_unspecified
+        )
+
+    # If host is a literal IP, validate directly.
+    try:
+        if not _is_public_ip(host):
+            raise ValueError("URL host resolves to a non-public IP address.")
+        return parsed.geturl()
+    except ValueError:
+        # Not an IP literal, continue with DNS resolution.
+        pass
+
+    # Resolve DNS and ensure every resolved address is public.
+    try:
+        addrinfo = socket.getaddrinfo(host, parsed.port or (443 if parsed.scheme == "https" else 80), proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        raise ValueError("Could not resolve URL hostname.")
+
+    resolved_ips = {ai[4][0] for ai in addrinfo}
+    if not resolved_ips:
+        raise ValueError("Could not resolve URL hostname.")
+
+    for ip_str in resolved_ips:
+        try:
+            if not _is_public_ip(ip_str):
+                raise ValueError("URL host resolves to a non-public IP address.")
+        except ValueError:
+            raise ValueError("URL host resolves to an invalid IP address.")
+
+    return parsed.geturl()
+
+
 def process_url(
     url: str,
     team_id: int,
@@ -583,9 +640,10 @@ def process_url(
 
     Raises ValueError on failure.
     """
+    validated_url = validate_public_http_url(url)
     try:
-        with httpx.Client(follow_redirects=True, timeout=30.0) as client:
-            resp = client.get(url, headers={"User-Agent": "LogiPlanner/1.0"})
+        with httpx.Client(follow_redirects=False, timeout=30.0) as client:
+            resp = client.get(validated_url, headers={"User-Agent": "LogiPlanner/1.0"})
     except httpx.TimeoutException:
         raise ValueError("Request timed out when fetching the URL.")
     except httpx.RequestError as e:

--- a/app/rag/processor.py
+++ b/app/rag/processor.py
@@ -587,18 +587,17 @@ def validate_public_http_url(url: str) -> str:
 
     host = parsed.hostname
 
-    def _is_public_ip(ip_str: str) -> bool:
-        ip_obj = ipaddress.ip_address(ip_str)
-        return ip_obj.is_global
-
     # If host is a literal IP, validate directly.
     try:
-        if not _is_public_ip(host):
+        ip_literal = ipaddress.ip_address(host)
+    except ValueError:
+        # Not an IP literal — fall through to DNS resolution.
+        ip_literal = None
+
+    if ip_literal is not None:
+        if not ip_literal.is_global:
             raise ValueError("URL host resolves to a non-public IP address.")
         return parsed.geturl()
-    except ValueError:
-        # Not an IP literal, continue with DNS resolution.
-        pass
 
     # Resolve DNS and ensure every resolved address is public.
     try:
@@ -612,10 +611,11 @@ def validate_public_http_url(url: str) -> str:
 
     for ip_str in resolved_ips:
         try:
-            if not _is_public_ip(ip_str):
-                raise ValueError("URL host resolves to a non-public IP address.")
+            ip_obj = ipaddress.ip_address(ip_str)
         except ValueError:
             raise ValueError("URL host resolves to an invalid IP address.")
+        if not ip_obj.is_global:
+            raise ValueError("URL host resolves to a non-public IP address.")
 
     return parsed.geturl()
 


### PR DESCRIPTION
Potential fix for [https://github.com/LogiPlanner/logiplanner/security/code-scanning/8](https://github.com/LogiPlanner/logiplanner/security/code-scanning/8)

To fix this without changing intended functionality (URL ingestion), keep accepting user URLs but **validate and constrain network destinations** before requesting them:

- Parse URL with `urllib.parse.urlparse`.
- Require `http`/`https` scheme and non-empty hostname.
- Reject direct IPs or resolved IPs that are private, loopback, link-local, multicast, reserved, or unspecified.
- Resolve hostname via DNS and ensure **all** resolved addresses are public.
- Disable automatic redirects (`follow_redirects=False`) to avoid redirect-based bypass to internal hosts.
- In API layer, call this validator before creating/fetching document; in processor layer, perform defense-in-depth validation again before `client.get`.

### Files/regions to change
- `app/rag/processor.py`: add URL safety helper and enforce it in `process_url` right before the request; set `follow_redirects=False`.
- `app/api/v1/rag.py`: validate `url` with processor helper after basic scheme check and before creating the document/fetching.

No external dependency is needed; use stdlib (`urllib.parse`, `ipaddress`, `socket`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
